### PR TITLE
Quash TypeError potentially raised by requests -> urllib3 (#488)

### DIFF
--- a/geopy/adapters.py
+++ b/geopy/adapters.py
@@ -428,7 +428,16 @@ class RequestsAdapter(BaseSyncAdapter):
         # instances are getting garbage-collected.
         session = getattr(self, "session", None)
         if session is not None:
-            session.close()
+            try:
+                session.close()
+            except TypeError:
+                # It's possible for the close method to try to fetch a
+                # non-existent old_pool in urllib3 with a misleading state
+                # ultimately due to stdlib queue/threading behaviour.
+                # Since the error arises from a non-existent pool
+                # (TypeError: 'NoneType' object is not callable)
+                # it's safe to ignore this error
+                pass
 
     def get_text(self, url, *, timeout, headers):
         resp = self._request(url, timeout=timeout, headers=headers)


### PR DESCRIPTION
Quashes an error raised by requests -> urllib3 -> stdlib:queue -> stdlib:threading where a pool may be done in a thread and therefore no object to close.

Error encountered in both Python 3.7.8 on Windows 10 and 3.7.11 on Debian 10 ( Docker: python3.7-slim). 


Exception ignored in: <function RequestsAdapter.__del__ at 0x7fd2c3fee170>
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/geopy/adapters.py", line 431, in __del__
  File "/usr/local/lib/python3.7/site-packages/requests/sessions.py", line 747, in close
  File "/usr/local/lib/python3.7/site-packages/requests/adapters.py", line 325, in close
  File "/usr/local/lib/python3.7/site-packages/urllib3/poolmanager.py", line 222, in clear
  File "/usr/local/lib/python3.7/site-packages/urllib3/_collections.py", line 100, in clear
  File "/usr/local/lib/python3.7/site-packages/urllib3/poolmanager.py", line 173, in <lambda>
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 490, in close
  File "/usr/local/lib/python3.7/queue.py", line 181, in get
  File "/usr/local/lib/python3.7/threading.py", line 348, in notify
TypeError: 'NoneType' object is not callable